### PR TITLE
Http headers encoding

### DIFF
--- a/idealista/settings.py
+++ b/idealista/settings.py
@@ -27,7 +27,14 @@ DOWNLOADER_MIDDLEWARES = {
     'rotating_proxies.middlewares.BanDetectionMiddleware': 620    
 }
 
-DOWNLOAD_TIMEOUT = 3
+DEFAULT_REQUEST_HEADERS = {
+    'authority': 'www.idealista.com',
+    'upgrade-insecure-requests': '1',
+    'sec-fetch-site': 'none',
+    'sec-fetch-mode': 'navigate',
+    'sec-fetch-user': '?1',
+    'sec-fetch-dest':' document'
+}
 
 
 ###########################

--- a/idealista/settings.py
+++ b/idealista/settings.py
@@ -36,6 +36,8 @@ DEFAULT_REQUEST_HEADERS = {
     'sec-fetch-dest':' document'
 }
 
+FEED_EXPORT_ENCODING='latin-1'
+
 
 ###########################
 # User agent configurarion

--- a/idealista/settings.py
+++ b/idealista/settings.py
@@ -38,6 +38,8 @@ DEFAULT_REQUEST_HEADERS = {
 
 FEED_EXPORT_ENCODING='latin-1'
 
+DOWNLOAD_TIMEOUT = 10
+
 
 ###########################
 # User agent configurarion


### PR DESCRIPTION
* Adding HTTP Headers used in idealista.com
* Adding default encoding used in idealista.com (latin-1 | ISO 8859-1)
* Fix request timetout to 10 sec